### PR TITLE
Remove image if nothing found at current size

### DIFF
--- a/js/jquery-picture.js
+++ b/js/jquery-picture.js
@@ -162,6 +162,11 @@
 					sizes[num] = path;
 
 				});
+				
+				if (sizes[currentMedia] === undefined) {
+		                    element.find('img').remove();
+		                    return;
+		                }
 
 				if(element.find('img').length == 0){
 
@@ -211,6 +216,11 @@
 					sizes[num] = path;
 
 				});
+				
+				if (sizes[currentMedia] === undefined) {
+		                    element.find('img').remove();
+		                    return;
+		                }
 
 				if(element.find('img').length == 0){
 


### PR DESCRIPTION
Removes image if no default size is found for the current media query - i.e if no data-media is set, then only show images above the first set size.
