### PR TITLE
other data attributes on the FIGURE tag 

### DIFF
--- a/js/jquery-picture.js
+++ b/js/jquery-picture.js
@@ -228,14 +228,14 @@
 				$.each(mediaObj, function(media, path){
 
 					var num;
+					if (0 == media.indexOf('media')) {
+						num = media.replace(/[^\d.]/g, '');
 
-					num = media.replace(/[^\d.]/g, '');
+						if(!num)
+							num = 0;
 
-					if(!num)
-						num = 0;
-
-					sizes[num] = path;
-
+						sizes[num] = path;
+					}
 				});
 
 				if(element.find('img').length == 0){


### PR DESCRIPTION
I update the setFigure() function so that other data attributes are allowed on the FIGURE tag.

I found the pictures plugin was not working correctly in FF when I have a data-image-src attribute in my FIGURE tag to remember the original image path. This is how I workaround the issue. Please consider my request.

Thanks and regards
Cecilia
